### PR TITLE
refactor: standardize error response messages and improve exception h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Below is a simplified example of a JWT payload issued by the Auth Service. The c
 The current JWT payload includes more data, such as `email`, `phone`, and a `services` array with the user’s accessible services and roles. This has been simplified in the example above to reduce token size and improve security, as sensitive data should not be stored in the JWT.
 
 ## ✅ Things to Improve 
-- [ ] **Standardize Error Responses**: Implement a consistent error response format across all endpoints for better client-side handling.
+- [X] **Standardize Error Responses**: Implement a consistent error response format across all endpoints for better client-side handling.
 - [ ] **Improve Verification Access to from Auth Service to API Services**: Implement a more secure method for API Services to verify JWTs, such as using public/private key pairs instead of a shared secret.
 - [ ] **Simplify JWT Payload**: Remove sensitive data (e.g., `email`, `phone`) and the `services` array from the JWT to reduce its size and minimize data exposure risks.
 - [ ] **Maybe, Centralize Permission Checks**: Store service access and roles in a database (cached in Redis) and create an endpoint (e.g., `GET /api/v1/auth/permissions`) for services to dynamically check user access and roles.

--- a/src/app/helpers/password_validator.py
+++ b/src/app/helpers/password_validator.py
@@ -126,20 +126,3 @@ def validate_password_complexity(password: str) -> tuple[bool, list[str]]:
             ls_messages.append(message)
 
     return is_valid, ls_messages
-
-
-if __name__ == "__main__":
-    # create a test for validate_password
-    my_list_test = [
-        ("Test123!", "Test123!", "testuser"),
-        ("test", "test", "testuser"),
-        ("admin", "admin", "SuperUser"),
-    ]
-
-    for pwd, pwd_con, username in my_list_test:
-        result = PasswordValidate.validate_password(
-            pwd=pwd,
-            conf_pwd=pwd_con,
-            username=username,
-        )
-        print(f"{pwd=} {username=}: {result}")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -5,12 +5,14 @@ This module initializes the FastAPI application and defines the basic routes.
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
 from app.config import settings
 from app.integrations.redis import RedisHelper
+from app.middleware.error_response import handle_error_response
 from app.repositories.admin import AdminAsyncRepositories
 from app.repositories.auth import AuthAsyncRepositories
 from app.repositories.member import MemberAsyncRepositories
@@ -93,6 +95,12 @@ app.add_middleware(
 async def root():  # noqa: ANN201
     return RedirectResponse("/docs")
 
+
+# These two handlers can't be combined because they handle different exception types
+# HTTPException handles explicit raised exceptions
+app.add_exception_handler(HTTPException, handle_error_response)
+# RequestValidationError handles request validation failures
+app.add_exception_handler(RequestValidationError, handle_error_response)
 
 app.include_router(auth_router)
 app.include_router(admin_router)

--- a/src/app/middleware/error_response.py
+++ b/src/app/middleware/error_response.py
@@ -60,4 +60,14 @@ async def handle_error_response(
             content=data.model_dump(),
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
-    return exc
+    # Handle any other exceptions with a generic 500 error
+    data = JsonResponse(
+        data=None,
+        message="An unexpected error occurred",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        success=False,
+    )
+    return JSONResponse(
+        content=data.model_dump(),
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/src/app/middleware/error_response.py
+++ b/src/app/middleware/error_response.py
@@ -44,7 +44,7 @@ async def handle_error_response(
     # Handle RequestValidationError
     elif isinstance(exc, RequestValidationError):
         errors = exc.errors()
-    
+
         if errors:
             type_error = errors[0]["type"]
             location = " in ".join(str(item) for item in errors[0]["loc"])

--- a/src/app/middleware/error_response.py
+++ b/src/app/middleware/error_response.py
@@ -44,11 +44,14 @@ async def handle_error_response(
     # Handle RequestValidationError
     elif isinstance(exc, RequestValidationError):
         errors = exc.errors()
-
-        type_error = errors[0]["type"]
-        location = " in ".join(str(item) for item in errors[0]["loc"])
-        msg_error = errors[0]["msg"]
-        pesan = f"Invalid input. Please check and try again. {type_error=} | {location=}. {msg_error=}"
+    
+        if errors:
+            type_error = errors[0]["type"]
+            location = " in ".join(str(item) for item in errors[0]["loc"])
+            msg_error = errors[0]["msg"]
+            pesan = f"Invalid input. Please check and try again. {type_error=} | {location=}. {msg_error=}"
+        else:
+            pesan = "Invalid input. Please check and try again."
 
         data = JsonResponse(
             data=None,

--- a/src/app/middleware/error_response.py
+++ b/src/app/middleware/error_response.py
@@ -1,0 +1,63 @@
+from fastapi import HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.helpers.response_api import JsonResponse
+
+
+async def handle_error_response(
+    request: Request,  # noqa: ARG001
+    exc: HTTPException | RequestValidationError,
+) -> JSONResponse:
+    """Handle both HTTP exceptions and validation errors.
+
+    Parameters
+    ----------
+    request : Request
+        The request that caused the exception
+    exc : Union[HTTPException, RequestValidationError]
+        The exception that was raised
+
+    Returns
+    -------
+    JSONResponse
+        A formatted JSON response containing error details
+
+    """
+    # Handle HTTPException
+    if isinstance(exc, HTTPException):
+        msg = exc.detail
+        status_code = exc.status_code
+
+        if status_code < 200 or status_code >= 300:
+            data = JsonResponse(
+                data=None,
+                message=msg,
+                status_code=status_code,
+                success=False,
+            )
+            return JSONResponse(
+                content=data.model_dump(),
+                status_code=status_code,
+            )
+
+    # Handle RequestValidationError
+    elif isinstance(exc, RequestValidationError):
+        errors = exc.errors()
+
+        type_error = errors[0]["type"]
+        location = " in ".join(str(item) for item in errors[0]["loc"])
+        msg_error = errors[0]["msg"]
+        pesan = f"Invalid input. Please check and try again. {type_error=} | {location=}. {msg_error=}"
+
+        data = JsonResponse(
+            data=None,
+            message=pesan,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            success=False,
+        )
+        return JSONResponse(
+            content=data.model_dump(),
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    return exc

--- a/src/tests/test_app/routers/test_admin_routers.py
+++ b/src/tests/test_app/routers/test_admin_routers.py
@@ -228,7 +228,7 @@ async def test_get_list_users_no_data(async_client, db_conn, override_role_admin
 
     response_json = response.json()
     #! Note: the current implementation still not standarize error response, so we using `detail`
-    assert response_json["detail"] == "No users found."
+    assert response_json["message"] == "No users found."
 
 
 @pytest.mark.asyncio
@@ -326,7 +326,7 @@ async def test_get_user_superadmin_details_as_admin(async_client, db_conn, overr
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
     #! Note: the current implementation still not standarize error response, so we using `detail`
-    assert response_json["detail"] == "No users found."
+    assert response_json["message"] == "No users found."
 
 
 # ! ---------------------------------------------
@@ -425,7 +425,7 @@ async def test_update_user_details_admin_to_superadmin_forbidden(async_client, d
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Admin cannot update to superadmin."
+    assert response_json["message"] == "Admin cannot update to superadmin."
 
 
 @pytest.mark.asyncio
@@ -448,7 +448,7 @@ async def test_update_user_details_admin_to_admin_forbidden(async_client, db_con
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Admin cannot update to admin."
+    assert response_json["message"] == "Admin cannot update to admin."
 
 
 @pytest.mark.asyncio
@@ -476,7 +476,7 @@ async def test_update_user_details_superadmin_to_superadmin_forbidden(
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Superadmin cannot update to superadmin."
+    assert response_json["message"] == "Superadmin cannot update to superadmin."
 
 
 @pytest.mark.asyncio
@@ -499,7 +499,7 @@ async def test_update_user_details_user_not_found(async_client, db_conn_trans, o
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
     response_json = response.json()
-    assert response_json["detail"] == "No users found."
+    assert response_json["message"] == "No users found."
 
 
 @pytest.mark.asyncio
@@ -522,7 +522,7 @@ async def test_update_user_details_update_failed(async_client, db_conn_trans, ov
     # Assertions
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     response_json = response.json()
-    assert response_json["detail"] == "Failed to update user."
+    assert response_json["message"] == "Failed to update user."
 
 
 @pytest.mark.asyncio
@@ -596,7 +596,7 @@ async def test_delete_user_admin_to_superadmin_forbidden(async_client, db_conn_t
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Admin cannot update to superadmin."
+    assert response_json["message"] == "Admin cannot update to superadmin."
 
 
 @pytest.mark.asyncio
@@ -618,7 +618,7 @@ async def test_delete_user_admin_to_admin_forbidden(async_client, db_conn_trans,
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Admin cannot update to admin."
+    assert response_json["message"] == "Admin cannot update to admin."
 
 
 @pytest.mark.asyncio
@@ -642,7 +642,7 @@ async def test_delete_user_superadmin_to_superadmin_forbidden(
     # Assertions
     assert response.status_code == status.HTTP_403_FORBIDDEN
     response_json = response.json()
-    assert response_json["detail"] == "Superadmin cannot update to superadmin."
+    assert response_json["message"] == "Superadmin cannot update to superadmin."
 
 
 @pytest.mark.asyncio
@@ -664,7 +664,7 @@ async def test_delete_user_not_found(async_client, db_conn_trans, override_role_
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
     response_json = response.json()
-    assert response_json["detail"] == "No users found."
+    assert response_json["message"] == "No users found."
 
 
 @pytest.mark.asyncio
@@ -686,7 +686,7 @@ async def test_delete_user_update_failed(async_client, db_conn_trans, override_r
     # Assertions
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     response_json = response.json()
-    assert response_json["detail"] == "Failed to update user."
+    assert response_json["message"] == "Failed to update user."
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_app/routers/test_member_routers.py
+++ b/src/tests/test_app/routers/test_member_routers.py
@@ -96,7 +96,7 @@ async def test_get_member_details_not_found(async_client, db_conn, override_role
 
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "Member not found"
+    assert response.json()["message"] == "Member not found"
 
 
 @pytest.mark.asyncio
@@ -194,7 +194,7 @@ async def test_update_password_current_mismatch(async_client, db_conn_trans, ove
     # Assertions
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "Current password is incorrect"
+    assert response.json()["message"] == "Current password is incorrect"
 
 
 @pytest.mark.asyncio
@@ -330,7 +330,7 @@ async def test_update_mfa_invalid_code(async_client, db_conn_trans, override_rol
 
     # Assertions
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "Invalid MFA code provided"
+    assert response.json()["message"] == "Invalid MFA code provided"
 
 
 @pytest.mark.asyncio
@@ -431,7 +431,7 @@ async def test_update_profile_failure(async_client, db_conn_trans, override_role
 
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "Member not found"
+    assert response.json()["message"] == "Member not found"
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_app/routers/test_services_routers.py
+++ b/src/tests/test_app/routers/test_services_routers.py
@@ -312,7 +312,7 @@ async def test_get_service_by_uuid_not_found(async_client, db_conn, override_rol
 
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "Service not found"
+    assert response.json()["message"] == "Service not found"
 
 
 @pytest.mark.asyncio
@@ -421,7 +421,7 @@ async def test_create_service_name_exists(async_client, db_conn_trans, override_
 
     # Assertions
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "Service with this name already exists"
+    assert response.json()["message"] == "Service with this name already exists"
 
 
 @pytest.mark.asyncio
@@ -450,7 +450,7 @@ async def test_create_service_failure(async_client, db_conn_trans, override_role
 
     # Assertions
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.json()["detail"] == "Failed to create service"
+    assert response.json()["message"] == "Failed to create service"
 
 
 @pytest.mark.asyncio
@@ -564,7 +564,7 @@ async def test_update_service_not_found(async_client, db_conn_trans, override_ro
 
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "Service not found"
+    assert response.json()["message"] == "Service not found"
 
 
 @pytest.mark.asyncio
@@ -590,7 +590,7 @@ async def test_update_service_name_exists(async_client, db_conn_trans, override_
 
     # Assertions
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "Service with this name already exists"
+    assert response.json()["message"] == "Service with this name already exists"
 
 
 @pytest.mark.asyncio
@@ -616,7 +616,7 @@ async def test_update_service_failure(async_client, db_conn_trans, override_role
 
     # Assertions
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.json()["detail"] == "Failed to update service"
+    assert response.json()["message"] == "Failed to update service"
 
 
 @pytest.mark.asyncio
@@ -695,7 +695,7 @@ async def test_delete_service_not_found(async_client, db_conn_trans, override_ro
 
     # Assertions
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "Service not found"
+    assert response.json()["message"] == "Service not found"
 
 
 @pytest.mark.asyncio
@@ -717,7 +717,7 @@ async def test_delete_service_failure(async_client, db_conn_trans, override_role
 
     # Assertions
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.json()["detail"] == "Failed to delete service"
+    assert response.json()["message"] == "Failed to delete service"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **User description**
This pull request focuses on standardizing error responses across the application and implementing a consistent error handling mechanism. The most important changes include adding a centralized error handler, updating test cases to reflect the new error response format, and removing obsolete test code.

Improvements to error handling:

* [`src/app/main.py`](diffhunk://#diff-cbd2cbbd5d22a406b1fee81766bfb174f640f1ee6ef4c8f013351f2eae7ebe04L8-R15): Added exception handlers for `HTTPException` and `RequestValidationError` to use the new `handle_error_response` function. [[1]](diffhunk://#diff-cbd2cbbd5d22a406b1fee81766bfb174f640f1ee6ef4c8f013351f2eae7ebe04L8-R15) [[2]](diffhunk://#diff-cbd2cbbd5d22a406b1fee81766bfb174f640f1ee6ef4c8f013351f2eae7ebe04R99-R104)
* [`src/app/middleware/error_response.py`](diffhunk://#diff-e97b2076ed0c7ba3172839cb481fd48e3fa5b0d7bd87fb02521cd73e50b13b96R1-R63): Implemented the `handle_error_response` function to handle both HTTP exceptions and validation errors, returning a standardized JSON response.

Updates to test cases:

* [`src/tests/test_app/routers/test_admin_routers.py`](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL231-R231): Updated assertions to check for the `message` field instead of `detail` in error responses. [[1]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL231-R231) [[2]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL329-R329) [[3]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL428-R428) [[4]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL451-R451) [[5]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL479-R479) [[6]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL502-R502) [[7]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL525-R525) [[8]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL599-R599) [[9]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL621-R621) [[10]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL645-R645) [[11]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL667-R667) [[12]](diffhunk://#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aaL689-R689)
* [`src/tests/test_app/routers/test_member_routers.py`](diffhunk://#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9L99-R99): Updated assertions to check for the `message` field instead of `detail` in error responses. [[1]](diffhunk://#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9L99-R99) [[2]](diffhunk://#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9L197-R197) [[3]](diffhunk://#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9L333-R333) [[4]](diffhunk://#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9L434-R434)
* [`src/tests/test_app/routers/test_services_routers.py`](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L315-R315): Updated assertions to check for the `message` field instead of `detail` in error responses. [[1]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L315-R315) [[2]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L424-R424) [[3]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L453-R453) [[4]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L567-R567) [[5]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L593-R593) [[6]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L619-R619) [[7]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L698-R698) [[8]](diffhunk://#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5L720-R720)

Code cleanup:

* [`src/app/helpers/password_validator.py`](diffhunk://#diff-9c5a61f01c98064915d4a54b613df90f13b8e0fd5682020e491c970332ed68a7L129-L145): Removed obsolete test code from the `validate_password_complexity` function.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R146): Marked the task to standardize error responses as completed.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Standardized error response format across the application.
  - Added centralized error handler for HTTP and validation errors.
  - Updated exception handlers in `src/app/main.py`.

- Implemented `handle_error_response` function for consistent error handling.

- Updated test cases to validate the new error response format.

- Removed obsolete test code and improved test assertions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>password_validator.py</strong><dd><code>Removed obsolete test code for password validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-9c5a61f01c98064915d4a54b613df90f13b8e0fd5682020e491c970332ed68a7">+0/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>main.py</strong><dd><code>Added centralized exception handlers for error responses.</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-cbd2cbbd5d22a406b1fee81766bfb174f640f1ee6ef4c8f013351f2eae7ebe04">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error_response.py</strong><dd><code>Implemented centralized error response handling function.</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-e97b2076ed0c7ba3172839cb481fd48e3fa5b0d7bd87fb02521cd73e50b13b96">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_admin_routers.py</strong><dd><code>Updated test cases to validate standardized error responses.</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aa">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_member_routers.py</strong><dd><code>Updated member router tests for standardized error responses.</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-467359e7ac32668d1448015f8fece7778fdaaaf8a241f1efebe23d9416449bb9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_services_routers.py</strong><dd><code>Updated service router tests for standardized error responses.</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-5c759abbb37eab3229d31672beda8d6774b7ef718646a3724423b53f980a84a5">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Marked error response standardization as completed.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/19/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>