### PR TITLE
feat: add endpoint to update user service mappings and related except…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ The system consists of three main components:
 ### User Management (Admin) 👤
 - `GET /api/v1/admin/users`: Retrieve a list of all users (admin only).
 - `GET /api/v1/admin/users/{user_uuid}`: Get details of a specific user (admin only).
-- `PUT /api/v1/admin/users/{user_uuid}`: Update a user’s details (admin only).
+- `PUT /api/v1/admin/users/{user_uuid}`: Update a user's details (admin only).
 - `DELETE /api/v1/admin/users/{user_uuid}`: Delete a user (admin only).
+- `PUT /api/v1/admin/users/{user_uuid}/services`: Update service mappings for a user, replacing all existing mappings (admin only).
 
 ### Member Profile Management 🧑‍💻
 - `GET /api/v1/me`: Retrieve the authenticated user’s details.

--- a/src/app/exceptions/admin.py
+++ b/src/app/exceptions/admin.py
@@ -39,3 +39,11 @@ class SuperadminCannotUpdateSuperadminException(HTTPException):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Superadmin cannot update to superadmin.",
         )
+
+
+class UpdateUserServicesMappingFailedException(HTTPException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update user services mapping.",
+        )

--- a/src/app/schemas/users/admin/payload.py
+++ b/src/app/schemas/users/admin/payload.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 
 from pydantic import BaseModel, Field, model_validator
+from uuid_utils.compat import UUID
 
 from app.schemas.roles.base import UserRole
 
@@ -49,3 +50,13 @@ class UpdateUserByAdminPayload(BaseModel):
             if data.get(data_key) == "":
                 data[data_key] = None
         return data
+
+
+class UserServiceMapping(BaseModel):
+    service_uuid: UUID = Field(..., description="UUID of the service")
+    role_id: int = Field(..., description="ID of the role for this service")
+    is_active: bool = Field(True, description="Whether this service mapping is active")
+
+
+class UpdateUserServicesPayload(BaseModel):
+    services: list[UserServiceMapping] = Field(..., description="List of service mappings")


### PR DESCRIPTION
### **User description**
This pull request introduces several updates to the user service mappings functionality, including new API endpoints, exception handling, and corresponding tests. The most important changes are grouped by theme below:

### API Endpoints and Routing:
* Added a new endpoint `PUT /api/v1/admin/users/{user_uuid}/services` to update service mappings for a user, replacing all existing mappings. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R78) [[2]](diffhunk://#diff-c66ab1d6eb383d8424276c3728234afb8345424a41ddd185840639e984f18029R150-R187)

### Exception Handling:
* Introduced `UpdateUserServicesMappingFailedException` to handle failures when updating user service mappings. [[1]](diffhunk://#diff-60f123b4c70269b1f64f32d97c83ab43c00bdd259860682653ce34cf4ef4c773R42-R49) [[2]](diffhunk://#diff-44dcee0f815bf105bcaec87e400e3f704d766b7630e1db8d74437a152d7e75deR10)

### Database Operations:
* Added methods `delete_user_service_mappings` and `insert_user_service_mappings` to handle deletion and insertion of user service mappings in the database.
* Implemented `update_user_services` method in `AdminAsyncRepositories` to update user service mappings in the database.

### Payload and Schema:
* Created new schema classes `UserServiceMapping` and `UpdateUserServicesPayload` to validate the payload for updating user service mappings.

### Testing:
* Added comprehensive tests for the new `update_user_services` endpoint, including success cases, empty service list, permission checks, and failure scenarios.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added a new API endpoint to update user service mappings.
  - Endpoint: `PUT /api/v1/admin/users/{user_uuid}/services`.
  - Replaces all existing service mappings for a user.

- Implemented database operations for updating user service mappings.
  - Added methods to delete and insert user service mappings.
  - Created `update_user_services` method in `AdminAsyncRepositories`.

- Introduced new exception handling for service mapping updates.
  - Added `UpdateUserServicesMappingFailedException`.

- Enhanced payload validation with new schema classes.
  - Added `UserServiceMapping` and `UpdateUserServicesPayload` schemas.

- Comprehensive tests for the new endpoint and related functionality.
  - Covered success, failure, permission checks, and edge cases.

- Updated documentation to include the new endpoint.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>admin.py</strong><dd><code>Added exception for user service mapping failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-60f123b4c70269b1f64f32d97c83ab43c00bdd259860682653ce34cf4ef4c773">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>admin.py</strong><dd><code>Added database operations for user service mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-00e8c349ddc2bf57ece3b756763cb5ac4eff5c0d4e25f967306b2656f68a4ede">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin.py</strong><dd><code>Added API endpoint for updating user service mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-c66ab1d6eb383d8424276c3728234afb8345424a41ddd185840639e984f18029">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>payload.py</strong><dd><code>Added schemas for user service mapping payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-5da39f4997c6b07019310b8b4102330b3556e22db0ee90490269cdbcce0d40e0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin.py</strong><dd><code>Added service logic for updating user service mappings</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-44dcee0f815bf105bcaec87e400e3f704d766b7630e1db8d74437a152d7e75de">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_admin_routers.py</strong><dd><code>Added tests for updating user service mappings endpoint</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-dbc1b063f88d54e08137d754cb7d36794e7e9e3e84c9f7632420ae371fa424aa">+199/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Updated documentation for new user service mappings endpoint</code></dd></td>
  <td><a href="https://github.com/agfianf/fastapi-auth-service/pull/20/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>